### PR TITLE
ENT-3432: Remove internal registry hostname from github

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-REGISTRY=docker-registry.upshift.redhat.com/chainsaw
+REGISTRY=quay.io/candlepin

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -5,9 +5,6 @@ services:
   candlepin-base:
     build: candlepin-base/
     image: ${REGISTRY}/candlepin-base
-  candlepin-rhel7:
-    build: candlepin-rhel7/
-    image: ${REGISTRY}/candlepin-rhel7
 networks:
   default:
     driver: bridge

--- a/docker/gating-test-images/build.sh
+++ b/docker/gating-test-images/build.sh
@@ -6,7 +6,7 @@
 #   and loading/dumping of test data (temp-cp).
 # - All local images are removed after the push.
 
-REGISTRY=docker-registry.upshift.redhat.com/chainsaw
+REGISTRY=quay.io/candlepin
 
 retry() {
     local -r -i max_attempts="$1"; shift

--- a/docker/gating-test-images/run.sh
+++ b/docker/gating-test-images/run.sh
@@ -6,7 +6,7 @@
 # The postgresql container has a sql dump with the required test data and imports them
 # on startup.
 
-REGISTRY=docker-registry.upshift.redhat.com/chainsaw
+REGISTRY=quay.io/candlepin
 
 retry() {
     local -r -i max_attempts="$1"; shift

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -15,6 +15,9 @@ pipeline {
             }
         }
         stage('Test') {
+            environment {
+                CANDLEPIN_QUAY_BOT = credentials("candlepin-quay-bot")
+            }
             parallel {
                 stage('unit') {
                     // ensures that this stage will get assigned its own workspace


### PR DESCRIPTION
 - Updated the code to use `QUAY.IO` open source docker registry
 - Removed the code of candlepin-rhel7 image