### PR TITLE
ENT-3446: Make Jenkins run cloud auth spec

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -195,12 +195,13 @@ OPTIONS:
   -j <version>      use a specific Java version instead of the auto-detected default
   -v                enable verbose/debug output
   -i                internationalization - validate translation files
+  -k                run cloud registration rspec test suite (only for "hosted" mode)
   -a <arguments>    extra arguments to pass to the Candlepin deploy script (implies -d)
 HELP
 }
 
 ARGV=("$@")
-while getopts ":dtRqrHulsb:c:a:vj:i" opt; do
+while getopts ":dtRqrHulsb:c:a:vj:i:k" opt; do
     case $opt in
         d  ) DEPLOY="1";;
         t  )
@@ -246,6 +247,7 @@ while getopts ":dtRqrHulsb:c:a:vj:i" opt; do
         v  ) VERBOSE="1";;
         j  ) JAVA_VERSION="${OPTARG}";;
         i  ) TRANSLATE="1";;
+        k  ) CLOUD_AUTH_RSPEC="1";;
         ?  ) usage; exit;;
     esac
 done
@@ -428,6 +430,14 @@ fi
 if [ "$RSPEC" == "1" ]; then
     echo "Running rspec tests..."
     CLEAN_CP=1
+
+    # To run the cloud auth rspec test suite.
+    # We generate custom.yaml to enable the
+    # cloud auth property.
+    # This is valid only in hosted mode.
+    if [ "$CLOUD_AUTH_RSPEC" == "1" ] && [ "$HOSTED" == "1" ]; then
+      python jenkins/generate_custom_yaml.py
+    fi
 
     tee /var/log/candlepin/rspec.log < /tmp/teepipe &
     build_rspec $RSPEC_FILTER > /tmp/teepipe 2>&1

--- a/jenkins/generate_custom_yaml.py
+++ b/jenkins/generate_custom_yaml.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import yaml
+
+data={
+    "candlepin.conf": {
+        "auth_cloud_enable": "true",
+    }
+}
+
+f=open('server/custom.yaml','w')
+f.write(yaml.dump(data))
+f.close()

--- a/server/conf/candlepin.conf.template
+++ b/server/conf/candlepin.conf.template
@@ -64,5 +64,6 @@ org.quartz.dataSource.myDS.maxConnections=5
 #overriding custom.yaml settings to ensure hostedtest resources are available
 candlepin.standalone=false
 module.config.hosted.configuration.module=org.candlepin.hostedtest.AdapterOverrideModule
+candlepin.auth.cloud.enable=<%= candlepin.auth_cloud_enable || false %>
 <% } %>\
 <%= candlepin.additional_properties %>


### PR DESCRIPTION
 - Added a `generate_custom_yaml.py` to generate yaml file
   to override the `candlepin.auth.cloud.enable` property.
   This is called only when Jenkins is running hosted specs.